### PR TITLE
fix: add -n flag to echo command for basic token generation

### DIFF
--- a/quick-start/README.md
+++ b/quick-start/README.md
@@ -33,7 +33,7 @@ More on Atlassian tokens:
   ```
 * Create a Basic token from it using shell command below:
   ```bash
-  echo "<your-email>:<your-api-token>" | base64
+  echo -n "<your-email>:<your-api-token>" | base64
   ```
 * Copy the token value and use it in the `atlassian-accounts.json` file as a user account.
 


### PR DESCRIPTION
- Fix GitHub issue #14 by adding the -n flag to prevent newline characters from being included in the base64-encoded token
- Update quick-start/README.md to use `echo -n` instead of `echo` for basic token generation
- This prevents invalid tokens due to trailing newline characters