### PR TITLE
chore(deps): update Go dependencies and tools; remove gg replace override (mitranim/gow#48 resolved)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,9 +71,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-// Using gg v0.1.19 until https://github.com/mitranim/gow/issues/48 is fixed
-replace github.com/mitranim/gg => github.com/mitranim/gg v0.1.19
-
 tool (
 	github.com/gemyago/apigen
 	github.com/mitranim/gow

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitranim/gg v0.1.28 // indirect
-	github.com/mitranim/gow v0.0.0-20250328223101-576bf37beebc // indirect
+	github.com/mitranim/gow v0.0.0-20250813114836-466e175ff699 // indirect
 	github.com/narqo/go-badge v0.0.0-20230821190521-c9a75c019a59 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,6 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/mitranim/gg v0.1.19 h1:4eTg5lOekYzz5mSBh8J3ruJH08AywMO4VEzJGZTk0gk=
-github.com/mitranim/gg v0.1.19/go.mod h1:x2V+nJJOpeMl/XEoHou9zlTvFxYAcGOCqOAKpVkF0Yc=
 github.com/mitranim/gg v0.1.28 h1:+ip6d+rviDUztbsWY5I+Izp4UZnOr46gz//AAzuV1SI=
 github.com/mitranim/gg v0.1.28/go.mod h1:x2V+nJJOpeMl/XEoHou9zlTvFxYAcGOCqOAKpVkF0Yc=
 github.com/mitranim/gow v0.0.0-20250328223101-576bf37beebc h1:G2MXqwcUGomN6t6QXAp2FCvQISuCdN2Hv6DkLvuDkdE=

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitranim/gg v0.1.28 h1:+ip6d+rviDUztbsWY5I+Izp4UZnOr46gz//AAzuV1SI=
 github.com/mitranim/gg v0.1.28/go.mod h1:x2V+nJJOpeMl/XEoHou9zlTvFxYAcGOCqOAKpVkF0Yc=
-github.com/mitranim/gow v0.0.0-20250328223101-576bf37beebc h1:G2MXqwcUGomN6t6QXAp2FCvQISuCdN2Hv6DkLvuDkdE=
-github.com/mitranim/gow v0.0.0-20250328223101-576bf37beebc/go.mod h1:5EoX+lDjxFS8FsGddO+JvLbf5xUzga7UgM5Hh5ZGjco=
+github.com/mitranim/gow v0.0.0-20250813114836-466e175ff699 h1:1SmNJMZpxH8RvmEpsEQePQA1EQUuERXmspJ7DpGX0lA=
+github.com/mitranim/gow v0.0.0-20250813114836-466e175ff699/go.mod h1:u9z0VPXeuHx5lzkR6TJsX+fx0YzbLS+UZnp1HlBxeNU=
 github.com/narqo/go-badge v0.0.0-20230821190521-c9a75c019a59 h1:kbREB9muGo4sHLoZJD/E/IV8yK3Y15eEA9mYi/ztRsk=
 github.com/narqo/go-badge v0.0.0-20230821190521-c9a75c019a59/go.mod h1:m9BzkaxwU4IfPQi9ko23cmuFltayFe8iS0dlRlnEWiM=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=


### PR DESCRIPTION
- Remove temporary replace for github.com/mitranim/gg (pin v0.1.19) after mitranim/gow#48 resolution
- Update all module dependencies via go get -u ./... and go mod tidy
- Update tool modules: apigen, gow, mockery, go-test-coverage
- Verified build with go build ./...