### PR TITLE
Improve Bitbucket inline comments and MCP file content tool

### DIFF
--- a/.cursor/rules/golang.mdc
+++ b/.cursor/rules/golang.mdc
@@ -18,7 +18,7 @@ Please also apply [general.mdc](mdc:.cursor/rules/general.mdc) rules
 - use require.Error or require.ErrorIs when asserting errors
 - use faker (github.com/go-faker/faker/v4) to generate random texts
 - when tests ready show command to run tests in form and offer to run it: 
-  `go test -v ./<package path> --run <test name>`
+  `go test -v ./<package path> --run /<test pattern>/`
 - Use mockery to create mocks for dependencies, read [mockery.mdc](mdc:.cursor/rules/mockery.mdc) prior to using it
 
 ## Code Quality and Linting

--- a/.cursor/rules/tdd-auto.mdc
+++ b/.cursor/rules/tdd-auto.mdc
@@ -21,4 +21,4 @@ For each actionable step follow **the exact** protocol:
 * Run the test again and ensure it is successful
 * Proceed with next step **only** when you're fully done
 * When writting tests, prefer adding new test cases for new logic
-* **Important** to follow [testing-best-practices.md](mdc:doc/testing-best-practices.md)
+* **Important** to follow [testing-best-practices.md](../../doc/testing-best-practices.md)

--- a/doc/testing/bitbucket-mcp-integration-tests.md
+++ b/doc/testing/bitbucket-mcp-integration-tests.md
@@ -295,48 +295,29 @@ This test verifies the end-to-end functionality of the Bitbucket PR review tools
      - description: "This is an automated PR review tools test (Test 5)"
    - Extract and save the PR ID for subsequent steps
    - Ensure the PR includes the two TypeScript files and the three text files.
-   - Use the PR diff to identify the exact line numbers for all `// Update marker` comments in both TypeScript files.
-   - Add inline comments to each marker in both files using the diff line numbers. This will verify if comments are properly added for new files.
 
-3. **List and verify PR comments and line numbers**
+3. **Check diffs**
+   - Use the PR diff stat tool to get a list of files that are changed in the PR. Check if all expected files are present.
+   - Use PR diff tool to get a diff for two files at once. Check if the diff is correct and expected.
+
+4. **Check file contents and create inline comments**
+   - For each file (example1.ts and example2.ts):
+     - Use get file content tool. Make sure it succeeds. Ensure the content is correct and expected.
+     - **IMPORTANT**: Using the **file content**, identify line numbers with update markers. Use `cat -n` to understand the line numbers.
+     - Add inline comments for each marker in the file. Include used line number in the comment message for better visibility.
+
+5. **List and verify PR comments and line numbers**
    - Use the `mcp.bitbucket_list_pr_comments` tool to list all comments for the PR.
    - For each comment on a TypeScript file:
-     - Use the `mcp.bitbucket_get_file_content` tool to fetch the full file content from the PR branch.
+     - Use the `mcp.bitbucket_get_file_content` tool to fetch the full file content.
      - Write the fetched file content to a uniquely named file in the `tmp/` directory in the current workspace, including a timestamp in the filename (e.g., `tmp/example1-<timestamp>.ts`).
-     - Use the following one-liner script to determine the actual line numbers for all marker comments in the file:
+     - Use **exactly** the following one-liner script to determine the actual line numbers for all marker comments in the file:
        ```
-       grep -n "Update marker" <filename> | cut -d: -f1,2
-       ```
-     - Compare the line numbers found by this script with the line numbers in the PR comments to verify mapping.
-   - This approach ensures that the verification uses the actual file content as fetched from Bitbucket and provides a reproducible, timestamped record of the verification process.
-
-4. **Create a derived branch and update markers**
-   - Create a new branch from the PR branch: `feature/pr-review-tools-test-derived-{timestamp}`
-   - For each `// Update marker` in both TypeScript files, update the marker by appending a timestamp or other unique text.
-   - Commit and push the changes.
-
-5. **Create a PR from the derived branch to the original PR branch**
-   - Create a PR from `feature/pr-review-tools-test-derived-{timestamp}` to `feature/pr-review-tools-test-{timestamp}`
-
-6. **Add inline comments to updated markers in the derived PR**
-   - Use the diff tool to locate changes and identify the new line numbers for all updated markers.
-   - Add inline comments to a selection of updated markers (at least one at the start, one in the middle, and one at the end of the files).
-
-7. **List and verify comments and line numbers in the derived PR**
-   - Use the `mcp.bitbucket_list_pr_comments` tool to list all comments for the derived PR.
-   - For each comment:
-     - Use the `mcp.bitbucket_get_file_content` tool to fetch the full file content from the derived PR branch.
-     - Write the fetched file content to a uniquely named file in the `tmp/` directory in the current workspace, including a timestamp in the filename (e.g., `tmp/example1-derived-<timestamp>.ts`).
-     - Use the following one-liner script to determine the actual line numbers for all marker comments in the file:
-       ```
-       grep -n "Update marker" <filename> | cut -d: -f1,2
+       cat -n <filename>
        ```
      - Compare the line numbers found by this script with the line numbers in the PR comments to verify mapping.
    - This approach ensures that the verification uses the actual file content as fetched from Bitbucket and provides a reproducible, timestamped record of the verification process.
 
-8. **Merge the derived PR**
-   - Merge (squash) the derived PR into the original PR branch.
-   - Continue with any other test steps that make sense for end-to-end review tool coverage.
 
 6. **Add a general (non-inline) comment to the PR**
    - Use the `mcp.bitbucket_add_pr_comment` tool to add a general comment (not associated with a file or line) to the PR, such as "General comment for PR review tools test {timestamp}".

--- a/doc/testing/bitbucket-mcp-integration-tests.md
+++ b/doc/testing/bitbucket-mcp-integration-tests.md
@@ -300,9 +300,15 @@ This test verifies the end-to-end functionality of the Bitbucket PR review tools
 
 3. **List and verify PR comments and line numbers**
    - Use the `mcp.bitbucket_list_pr_comments` tool to list all comments for the PR.
-   - For each comment on a TypeScript file, use the `mcp.bitbucket_get_file_content` tool to fetch the full file content from the PR branch.
-   - Locate the exact line for each marker by searching the file content for the full marker comment.
-   - Verify that the line number in the comment matches the actual line number in the file content. This ensures line numbers from the diff are correctly mapped to the file content.
+   - For each comment on a TypeScript file:
+     - Use the `mcp.bitbucket_get_file_content` tool to fetch the full file content from the PR branch.
+     - Write the fetched file content to a uniquely named file in the `tmp/` directory in the current workspace, including a timestamp in the filename (e.g., `tmp/example1-<timestamp>.ts`).
+     - Use the following one-liner script to determine the actual line numbers for all marker comments in the file:
+       ```
+       grep -n "Update marker" <filename> | cut -d: -f1,2
+       ```
+     - Compare the line numbers found by this script with the line numbers in the PR comments to verify mapping.
+   - This approach ensures that the verification uses the actual file content as fetched from Bitbucket and provides a reproducible, timestamped record of the verification process.
 
 4. **Create a derived branch and update markers**
    - Create a new branch from the PR branch: `feature/pr-review-tools-test-derived-{timestamp}`
@@ -318,8 +324,15 @@ This test verifies the end-to-end functionality of the Bitbucket PR review tools
 
 7. **List and verify comments and line numbers in the derived PR**
    - Use the `mcp.bitbucket_list_pr_comments` tool to list all comments for the derived PR.
-   - For each comment, use the `mcp.bitbucket_get_file_content` tool to fetch the full file content from the derived PR branch.
-   - Locate the exact line for each updated marker and verify the comment's line number matches the actual line number in the file content.
+   - For each comment:
+     - Use the `mcp.bitbucket_get_file_content` tool to fetch the full file content from the derived PR branch.
+     - Write the fetched file content to a uniquely named file in the `tmp/` directory in the current workspace, including a timestamp in the filename (e.g., `tmp/example1-derived-<timestamp>.ts`).
+     - Use the following one-liner script to determine the actual line numbers for all marker comments in the file:
+       ```
+       grep -n "Update marker" <filename> | cut -d: -f1,2
+       ```
+     - Compare the line numbers found by this script with the line numbers in the PR comments to verify mapping.
+   - This approach ensures that the verification uses the actual file content as fetched from Bitbucket and provides a reproducible, timestamped record of the verification process.
 
 8. **Merge the derived PR**
    - Merge (squash) the derived PR into the original PR branch.

--- a/doc/testing/example1.ts
+++ b/doc/testing/example1.ts
@@ -1,0 +1,156 @@
+// Example TypeScript file: example1.ts
+// This file contains a variety of TypeScript constructs for testing purposes.
+// Update marker 1
+
+// --- Interfaces ---
+interface User {
+    id: number;
+    name: string;
+    email: string;
+    isActive: boolean;
+    roles: string[];
+}
+
+interface Product {
+    id: number;
+    name: string;
+    price: number;
+    tags?: string[];
+}
+
+// --- Enums ---
+enum LogLevel {
+    DEBUG = 'debug',
+    INFO = 'info',
+    WARN = 'warn',
+    ERROR = 'error',
+}
+
+// --- Classes ---
+class Logger {
+    private level: LogLevel;
+    constructor(level: LogLevel) {
+        this.level = level;
+    }
+    log(message: string, level: LogLevel = LogLevel.INFO) {
+        if (this.shouldLog(level)) {
+            console.log(`[${level}] ${message}`);
+        }
+    }
+    private shouldLog(level: LogLevel): boolean {
+        const order = [LogLevel.DEBUG, LogLevel.INFO, LogLevel.WARN, LogLevel.ERROR];
+        return order.indexOf(level) >= order.indexOf(this.level);
+    }
+}
+// Update marker 2
+
+// --- Functions ---
+function getUserById(users: User[], id: number): User | undefined {
+    return users.find(u => u.id === id);
+}
+
+function calculateTotal(products: Product[]): number {
+    return products.reduce((sum, p) => sum + p.price, 0);
+}
+
+function filterActiveUsers(users: User[]): User[] {
+    return users.filter(u => u.isActive);
+}
+
+function addRoleToUser(user: User, role: string): User {
+    return { ...user, roles: [...user.roles, role] };
+}
+
+// --- Generics ---
+function identity<T>(value: T): T {
+    return value;
+}
+
+function mapArray<T, U>(arr: T[], fn: (item: T) => U): U[] {
+    return arr.map(fn);
+}
+
+// --- Utility Types ---
+type ReadonlyUser = Readonly<User>;
+type PartialProduct = Partial<Product>;
+
+// --- Example Data ---
+const users: User[] = [
+    { id: 1, name: 'Alice', email: 'alice@example.com', isActive: true, roles: ['admin'] },
+    { id: 2, name: 'Bob', email: 'bob@example.com', isActive: false, roles: ['user'] },
+    { id: 3, name: 'Charlie', email: 'charlie@example.com', isActive: true, roles: ['user', 'editor'] },
+];
+// Update marker 3
+
+const products: Product[] = [
+    { id: 1, name: 'Laptop', price: 1200, tags: ['electronics', 'computers'] },
+    { id: 2, name: 'Phone', price: 800 },
+    { id: 3, name: 'Book', price: 20, tags: ['education'] },
+];
+
+// --- Main Logic ---
+const logger = new Logger(LogLevel.DEBUG);
+
+logger.log('Application started', LogLevel.INFO);
+
+const activeUsers = filterActiveUsers(users);
+logger.log(`Active users: ${activeUsers.map(u => u.name).join(', ')}`);
+
+const total = calculateTotal(products);
+logger.log(`Total price: $${total}`);
+
+const alice = getUserById(users, 1);
+if (alice) {
+    logger.log(`Found user: ${alice.name}`);
+}
+
+const newUser = addRoleToUser(users[1], 'editor');
+logger.log(`Updated user roles: ${newUser.roles.join(', ')}`);
+
+const idVal = identity<string>('test');
+logger.log(`Identity function returned: ${idVal}`);
+
+const mapped = mapArray<number, string>([1, 2, 3], n => `Number: ${n}`);
+logger.log(`Mapped array: ${mapped.join('; ')}`);
+
+// --- File Operations (Mocked) ---
+function saveDataToFile(filename: string, data: string) {
+    // Simulate file save
+    logger.log(`Data would be saved to ${filename}`);
+}
+
+saveDataToFile('output.txt', JSON.stringify(users));
+// Update marker 4
+
+// --- More Example Code ---
+for (let i = 0; i < 10; i++) {
+    logger.log(`Loop iteration: ${i}`);
+}
+
+function* idGenerator() {
+    let id = 0;
+    while (true) {
+        yield id++;
+    }
+}
+
+const gen = idGenerator();
+for (let i = 0; i < 5; i++) {
+    logger.log(`Generated id: ${gen.next().value}`);
+}
+
+class Calculator {
+    add(a: number, b: number): number {
+        return a + b;
+    }
+    multiply(a: number, b: number): number {
+        return a * b;
+    }
+}
+
+const calc = new Calculator();
+logger.log(`Calc add: ${calc.add(2, 3)}`);
+logger.log(`Calc multiply: ${calc.multiply(4, 5)}`);
+
+// --- End of File ---
+// Update marker 5

--- a/doc/testing/example1.ts
+++ b/doc/testing/example1.ts
@@ -2,6 +2,7 @@
 // This file contains a variety of TypeScript constructs for testing purposes.
 // Update marker 1
 
+(() => {
 // --- Interfaces ---
 interface User {
     id: number;
@@ -154,3 +155,4 @@ logger.log(`Calc multiply: ${calc.multiply(4, 5)}`);
 
 // --- End of File ---
 // Update marker 5
+})();

--- a/doc/testing/example2.ts
+++ b/doc/testing/example2.ts
@@ -2,6 +2,7 @@
 // This file demonstrates more advanced TypeScript features and patterns.
 // Update marker 1
 
+(() => {
 // --- Types and Interfaces ---
 type UUID = string;
 
@@ -163,12 +164,12 @@ class Service {
 const service = new Service('NotificationService');
 service.start();
 
-// --- Example of Namespaces ---
-namespace MathUtils {
-    export function add(a: number, b: number): number {
+// --- Example of Static Methods ---
+class MathUtils {
+    static add(a: number, b: number): number {
         return a + b;
     }
-    export function multiply(a: number, b: number): number {
+    static multiply(a: number, b: number): number {
         return a * b;
     }
 }
@@ -178,3 +179,4 @@ console.log('Math multiply:', MathUtils.multiply(4, 5));
 
 // --- End of File ---
 // Update marker 4
+})();

--- a/doc/testing/example2.ts
+++ b/doc/testing/example2.ts
@@ -1,0 +1,180 @@
+// Example TypeScript file: example2.ts
+// This file demonstrates more advanced TypeScript features and patterns.
+// Update marker 1
+
+// --- Types and Interfaces ---
+type UUID = string;
+
+interface Task {
+    id: UUID;
+    title: string;
+    completed: boolean;
+    dueDate?: Date;
+}
+
+interface Project {
+    id: UUID;
+    name: string;
+    tasks: Task[];
+}
+
+// --- Enums ---
+enum TaskStatus {
+    TODO = 'todo',
+    IN_PROGRESS = 'in_progress',
+    DONE = 'done',
+}
+
+// --- Classes ---
+class TaskManager {
+    private tasks: Map<UUID, Task> = new Map();
+    private listeners: { [event: string]: Function[] } = {};
+    // Update marker 2
+    addTask(task: Task) {
+        this.tasks.set(task.id, task);
+        this.emit('taskAdded', task);
+    }
+    completeTask(id: UUID) {
+        const task = this.tasks.get(id);
+        if (task) {
+            task.completed = true;
+            this.emit('taskCompleted', task);
+        }
+    }
+    getTasks(): Task[] {
+        return Array.from(this.tasks.values());
+    }
+    getPendingTasks(): Task[] {
+        return this.getTasks().filter(t => !t.completed);
+    }
+    removeTask(id: UUID) {
+        this.tasks.delete(id);
+        this.emit('taskRemoved', id);
+    }
+    on(event: string, listener: Function) {
+        if (!this.listeners[event]) {
+            this.listeners[event] = [];
+        }
+        this.listeners[event].push(listener);
+    }
+    emit(event: string, ...args: any[]) {
+        if (this.listeners[event]) {
+            for (const listener of this.listeners[event]) {
+                listener(...args);
+            }
+        }
+    }
+}
+
+// --- Utility Functions ---
+function generateUUID(): UUID {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+        const r = Math.random() * 16 | 0, v = c === 'x' ? r : (r & 0x3 | 0x8);
+        return v.toString(16);
+    });
+}
+
+function createTask(title: string, dueDate?: Date): Task {
+    return {
+        id: generateUUID(),
+        title,
+        completed: false,
+        dueDate,
+    };
+}
+
+function createProject(name: string): Project {
+    return {
+        id: generateUUID(),
+        name,
+        tasks: [],
+    };
+}
+
+// --- Example Data ---
+const project = createProject('AI Project');
+const task1 = createTask('Design API', new Date('2024-07-01'));
+const task2 = createTask('Implement backend');
+const task3 = createTask('Write tests', new Date('2024-07-10'));
+project.tasks.push(task1, task2, task3);
+
+// --- Task Manager Usage ---
+const manager = new TaskManager();
+manager.on('taskAdded', (task: Task) => {
+    console.log(`Task added: ${task.title}`);
+});
+manager.on('taskCompleted', (task: Task) => {
+    console.log(`Task completed: ${task.title}`);
+});
+manager.on('taskRemoved', (id: UUID) => {
+    console.log(`Task removed: ${id}`);
+});
+
+for (const t of project.tasks) {
+    manager.addTask(t);
+}
+
+manager.completeTask(task1.id);
+manager.removeTask(task2.id);
+
+console.log('Pending tasks:', manager.getPendingTasks().map(t => t.title));
+
+// --- Advanced Types ---
+type TaskMap = Record<UUID, Task>;
+type ProjectWithStatus = Project & { status: TaskStatus };
+
+// --- Example of Type Guards ---
+function isProject(obj: any): obj is Project {
+    return obj && typeof obj.id === 'string' && Array.isArray(obj.tasks);
+}
+
+// --- Example of Promises and Async/Await ---
+async function fetchProject(id: UUID): Promise<Project> {
+    // Simulate async fetch
+    // Update marker 3
+    return new Promise(resolve => {
+        setTimeout(() => {
+            resolve(createProject('Fetched Project'));
+        }, 100);
+    });
+}
+
+// --- Example of Generics ---
+function wrapInArray<T>(item: T): T[] {
+    return [item];
+}
+
+// --- Example of Decorators ---
+function logClass(target: Function) {
+    console.log(`Class created: ${target.name}`);
+}
+
+@logClass
+class Service {
+    name: string;
+    constructor(name: string) {
+        this.name = name;
+    }
+    start() {
+        console.log(`${this.name} started`);
+    }
+}
+
+const service = new Service('NotificationService');
+service.start();
+
+// --- Example of Namespaces ---
+namespace MathUtils {
+    export function add(a: number, b: number): number {
+        return a + b;
+    }
+    export function multiply(a: number, b: number): number {
+        return a * b;
+    }
+}
+
+console.log('Math add:', MathUtils.add(2, 3));
+console.log('Math multiply:', MathUtils.multiply(4, 5));
+
+// --- End of File ---
+// Update marker 4

--- a/internal/api/mcp/controllers/bitbucket.go
+++ b/internal/api/mcp/controllers/bitbucket.go
@@ -1057,8 +1057,8 @@ func (bc *BitbucketController) newGetFileContentServerTool() server.ServerTool {
 			mcp.Description("Path to the file in the repository"),
 			mcp.Required(),
 		),
-		mcp.WithString("commit",
-			mcp.Description("Commit hash to fetch file content from (required)"),
+		mcp.WithString("commit_hash",
+			mcp.Description("The SHA hash to fetch file content from. Only commit hashes are supported."),
 			mcp.Required(),
 		),
 	)
@@ -1082,9 +1082,9 @@ func (bc *BitbucketController) newGetFileContentServerTool() server.ServerTool {
 				"Missing or invalid file_path parameter: required argument \"file_path\" not found",
 			), nil
 		}
-		commit, err := request.RequireString("commit")
+		commitHash, err := request.RequireString("commit_hash")
 		if err != nil {
-			return mcp.NewToolResultErrorFromErr("Missing or invalid commit parameter", err), nil
+			return mcp.NewToolResultErrorFromErr("Missing or invalid commit_hash parameter", err), nil
 		}
 		account := request.GetString("account", "")
 
@@ -1092,7 +1092,7 @@ func (bc *BitbucketController) newGetFileContentServerTool() server.ServerTool {
 			AccountName: account,
 			RepoOwner:   repoOwner,
 			RepoName:    repoName,
-			Commit:      commit,
+			Commit:      commitHash,
 			Path:        filePath,
 		}
 

--- a/internal/api/mcp/controllers/bitbucket.go
+++ b/internal/api/mcp/controllers/bitbucket.go
@@ -1058,7 +1058,8 @@ func (bc *BitbucketController) newGetFileContentServerTool() server.ServerTool {
 			mcp.Required(),
 		),
 		mcp.WithString("commit",
-			mcp.Description("Commit hash to fetch file content from (optional, defaults to main branch)"),
+			mcp.Description("Commit hash to fetch file content from (required)"),
+			mcp.Required(),
 		),
 	)
 	handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -1081,7 +1082,10 @@ func (bc *BitbucketController) newGetFileContentServerTool() server.ServerTool {
 				"Missing or invalid file_path parameter: required argument \"file_path\" not found",
 			), nil
 		}
-		commit := request.GetString("commit", "")
+		commit, err := request.RequireString("commit")
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("Missing or invalid commit parameter", err), nil
+		}
 		account := request.GetString("account", "")
 
 		params := app.BitbucketGetFileContentParams{

--- a/internal/api/mcp/controllers/bitbucket.go
+++ b/internal/api/mcp/controllers/bitbucket.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"strings"
 
 	"github.com/gemyago/atlacp/internal/app"
 	"github.com/gemyago/atlacp/internal/services/bitbucket"
@@ -960,9 +961,8 @@ func (bc *BitbucketController) newGetPRDiffServerTool() server.ServerTool {
 		mcp.WithString("account",
 			mcp.Description("Atlassian account name to use (optional, uses default if not specified)"),
 		),
-		mcp.WithArray("file_paths",
-			mcp.Description("List of file paths to filter the diff (optional)"),
-			mcp.Items("string"),
+		mcp.WithString("file_paths",
+			mcp.Description("List of file paths to filter the diff (optional, multiple comma-separated values are possible)"),
 		),
 		mcp.WithNumber("context_lines",
 			mcp.Description("Number of context lines to include in the diff (optional)"),
@@ -988,7 +988,17 @@ func (bc *BitbucketController) newGetPRDiffServerTool() server.ServerTool {
 		account := request.GetString("account", "")
 
 		// Extract optional file_paths and context_lines using idiomatic helpers
-		filePaths := request.GetStringSlice("file_paths", nil)
+		filePathsStr := request.GetString("file_paths", "")
+		var filePaths []string
+		if filePathsStr != "" {
+			parts := strings.Split(filePathsStr, ",")
+			for _, s := range parts {
+				s = strings.TrimSpace(s)
+				if s != "" {
+					filePaths = append(filePaths, s)
+				}
+			}
+		}
 		var contextLines *int
 		if cl := request.GetInt("context_lines", 0); cl != 0 {
 			contextLines = &cl

--- a/internal/api/mcp/controllers/bitbucket_test.go
+++ b/internal/api/mcp/controllers/bitbucket_test.go
@@ -3410,6 +3410,40 @@ func TestBitbucketController(t *testing.T) {
 			require.True(t, ok)
 			assert.Contains(t, content.Text, "Missing or invalid repo_owner parameter")
 		})
+
+		t.Run("should error if commit is missing", func(t *testing.T) {
+			// Arrange
+			deps := makeMockDeps(t)
+			controller := NewBitbucketController(deps)
+			ctx := t.Context()
+
+			// Missing commit
+			request := mcp.CallToolRequest{
+				Params: mcp.CallToolParams{
+					Name: "bitbucket_get_file_content",
+					Arguments: map[string]interface{}{
+						"repo_owner": "workspace-" + faker.Username(),
+						"repo_name":  "repo-" + faker.Word(),
+						"path":       faker.Word() + ".go",
+						"account":    "account-" + faker.Username(),
+					},
+				},
+			}
+
+			serverTool := controller.newGetFileContentServerTool()
+			handler := serverTool.Handler
+
+			// Act
+			result, err := handler(ctx, request)
+
+			// Assert
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.True(t, result.IsError)
+			content, ok := result.Content[0].(mcp.TextContent)
+			require.True(t, ok)
+			assert.Contains(t, content.Text, "Missing or invalid commit parameter")
+		})
 	})
 
 	t.Run("bitbucket_get_pr_diff", func(t *testing.T) {

--- a/internal/api/mcp/controllers/bitbucket_test.go
+++ b/internal/api/mcp/controllers/bitbucket_test.go
@@ -3344,7 +3344,7 @@ func TestBitbucketController(t *testing.T) {
 			repoOwner := "workspace-" + faker.Username()
 			repoName := "repo-" + faker.Word()
 			filePath := faker.Word() + ".go"
-			commit_hash := "main"
+			commitHash := "main"
 			accountName := "account-" + faker.Username()
 			expectedErr := errors.New("bitbucket service failure: " + faker.Sentence())
 
@@ -3359,7 +3359,7 @@ func TestBitbucketController(t *testing.T) {
 						"repo_owner":  repoOwner,
 						"repo_name":   repoName,
 						"path":        filePath,
-						"commit_hash": commit_hash,
+						"commit_hash": commitHash,
 						"account":     accountName,
 					},
 				},

--- a/internal/api/mcp/controllers/bitbucket_test.go
+++ b/internal/api/mcp/controllers/bitbucket_test.go
@@ -3500,7 +3500,7 @@ func TestBitbucketController(t *testing.T) {
 						"repo_owner":    repoOwner,
 						"repo_name":     repoName,
 						"account":       accountName,
-						"file_paths":    filePaths,
+						"file_paths":    filePaths[0] + ", " + filePaths[1],
 						"context_lines": contextLines,
 					},
 				},
@@ -3848,7 +3848,7 @@ func TestBitbucketController(t *testing.T) {
 						"repo_owner": repoOwner,
 						"repo_name":  repoName,
 						"account":    accountName,
-						"file_paths": filePaths,
+						"file_paths": filePaths[0] + ", " + filePaths[1],
 					},
 				},
 			}

--- a/internal/api/mcp/controllers/bitbucket_test.go
+++ b/internal/api/mcp/controllers/bitbucket_test.go
@@ -3275,7 +3275,7 @@ func TestBitbucketController(t *testing.T) {
 			repoOwner := "workspace-" + faker.Username()
 			repoName := "repo-" + faker.Word()
 			filePath := faker.Word() + ".go"
-			commit := "main"
+			commitHash := "main"
 			accountName := "account-" + faker.Username()
 			expectedContent := "package main\n\nfunc main() {}\n"
 
@@ -3285,7 +3285,7 @@ func TestBitbucketController(t *testing.T) {
 					return params.RepoOwner == repoOwner &&
 						params.RepoName == repoName &&
 						params.Path == filePath &&
-						params.Commit == commit &&
+						params.Commit == commitHash &&
 						params.AccountName == accountName
 				})).
 				Return(&bitbucket.FileContentResult{
@@ -3302,11 +3302,11 @@ func TestBitbucketController(t *testing.T) {
 				Params: mcp.CallToolParams{
 					Name: "bitbucket_get_file_content",
 					Arguments: map[string]interface{}{
-						"repo_owner": repoOwner,
-						"repo_name":  repoName,
-						"path":       filePath,
-						"commit":     commit,
-						"account":    accountName,
+						"repo_owner":  repoOwner,
+						"repo_name":   repoName,
+						"path":        filePath,
+						"commit_hash": commitHash,
+						"account":     accountName,
 					},
 				},
 			}
@@ -3344,7 +3344,7 @@ func TestBitbucketController(t *testing.T) {
 			repoOwner := "workspace-" + faker.Username()
 			repoName := "repo-" + faker.Word()
 			filePath := faker.Word() + ".go"
-			commit := "main"
+			commit_hash := "main"
 			accountName := "account-" + faker.Username()
 			expectedErr := errors.New("bitbucket service failure: " + faker.Sentence())
 
@@ -3356,11 +3356,11 @@ func TestBitbucketController(t *testing.T) {
 				Params: mcp.CallToolParams{
 					Name: "bitbucket_get_file_content",
 					Arguments: map[string]interface{}{
-						"repo_owner": repoOwner,
-						"repo_name":  repoName,
-						"path":       filePath,
-						"commit":     commit,
-						"account":    accountName,
+						"repo_owner":  repoOwner,
+						"repo_name":   repoName,
+						"path":        filePath,
+						"commit_hash": commit_hash,
+						"account":     accountName,
 					},
 				},
 			}
@@ -3388,10 +3388,10 @@ func TestBitbucketController(t *testing.T) {
 				Params: mcp.CallToolParams{
 					Name: "bitbucket_get_file_content",
 					Arguments: map[string]interface{}{
-						"repo_name": "repo-" + faker.Word(),
-						"path":      faker.Word() + ".go",
-						"commit":    "main",
-						"account":   "account-" + faker.Username(),
+						"repo_name":   "repo-" + faker.Word(),
+						"path":        faker.Word() + ".go",
+						"commit_hash": "main",
+						"account":     "account-" + faker.Username(),
 					},
 				},
 			}
@@ -3411,13 +3411,13 @@ func TestBitbucketController(t *testing.T) {
 			assert.Contains(t, content.Text, "Missing or invalid repo_owner parameter")
 		})
 
-		t.Run("should error if commit is missing", func(t *testing.T) {
+		t.Run("should error if commit_hash is missing", func(t *testing.T) {
 			// Arrange
 			deps := makeMockDeps(t)
 			controller := NewBitbucketController(deps)
 			ctx := t.Context()
 
-			// Missing commit
+			// Missing commit_hash
 			request := mcp.CallToolRequest{
 				Params: mcp.CallToolParams{
 					Name: "bitbucket_get_file_content",
@@ -3442,7 +3442,7 @@ func TestBitbucketController(t *testing.T) {
 			assert.True(t, result.IsError)
 			content, ok := result.Content[0].(mcp.TextContent)
 			require.True(t, ok)
-			assert.Contains(t, content.Text, "Missing or invalid commit parameter")
+			assert.Contains(t, content.Text, "Missing or invalid commit_hash parameter")
 		})
 	})
 


### PR DESCRIPTION
* Refactor Bitbucket get_file_content tool: rename 'commit' param to 'commit_hash' and require it
* Update controller and handler tests for new parameter
* Add test for missing commit param
* Change file_paths param to comma-separated string for MCP compatibility
* Update integration tests for inline and general comments, line number checks, and TypeScript files
* Add standalone TypeScript example files for integration testing
* Various test and refactoring improvements