### PR TITLE
Fix publish npm workflow input description

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Version to publish (for example: v1.2.3)
+        description: Version to publish (for example v1.2.3)
         required: true
         type: string
 


### PR DESCRIPTION
# Focus of the changes
This change fixes the wording of the manual publish workflow input so it reads cleanly and consistently in GitHub Actions.

# High level summary of the changes
* Update the `version` input description in `.github/workflows/publish-npm.yml`