### PR TITLE
Fix npm publish checkout ref

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.version || github.event.release.tag_name }}
           fetch-depth: 0
 
       - name: Set up Go

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Version to publish (for example: v1.2.3)
+        description: Version to publish (for example v1.2.3)
         required: true
         type: string
 


### PR DESCRIPTION
# Focus of the changes
Manual npm publish dispatches were checking out the version string instead of the branch the user selected in GitHub Actions. This change lets checkout follow the event ref by default, while the version input is only used for publishing.

# High level summary of the changes
* Removed the explicit checkout ref override from `.github/workflows/publish-npm.yml`
* Kept version resolution in the publish step so manual dispatch still publishes the requested version
* Preserved release-triggered publishing behavior through the release event ref/tag