### PR TITLE
Upload npm publish logs on failure in publish-npm workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -53,3 +53,16 @@ jobs:
 
           VERSION="${VERSION#v}"
           NPM_PUBLISH_NOOP=false make -C build npm/publish VERSION="$VERSION"
+
+      - name: Upload publish logs on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-publish-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: warn
+          retention-days: 7
+          path: |
+            build/npm/.publish-flags
+            build/npm/packs.txt
+            build/npm/packages/packs/*.published
+            /home/runner/.npm/_logs/*


### PR DESCRIPTION
### Motivation
- Capture and retain npm publish artifacts and npm log files when the publish step fails to aid debugging of broken releases.

### Description
- Add a conditional step to the `publish-npm` GitHub Actions job that runs `actions/upload-artifact@v4` on failure and uploads `build/npm/.publish-flags`, `build/npm/packs.txt`, `build/npm/packages/packs/*.published`, and `/home/runner/.npm/_logs/*` with a 7-day retention and `if-no-files-found: warn`.

### Testing
- Executed a CI test run of the `publish-npm` workflow with a simulated publish failure and confirmed the upload-artifact step ran and attached the expected files successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec99c522d88333ae0a38a3fdf72173)