### PR TITLE
Fix npm publish workflow auth setup

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -33,8 +33,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
+          node-version: "24"
 
       - name: Install Go dependencies
         run: go mod download && go install tool

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,9 @@ AI must **always** use `--noop` flag to dry-run startup checks without external 
 - Render chart: `helm template deploy/helm/api-service --debug --name-template api-service -f deploy/helm/api-service/values.yaml`
 - Install/upgrade (dry-run): `helm upgrade api-service deploy/helm/api-service --install --namespace atlacp -f deploy/helm/api-service/values.yaml --create-namespace --dry-run`
 
+## Release Workflows
+- GitHub release publishing workflows should use GitHub Actions OIDC/provenance directly and avoid `actions/setup-node` registry auth injection unless a token-based publish path is explicitly required.
+
 ## Configuration & Environment
 - Embedded configs: `internal/config/default.json`, `<env>.json`, optional `<env>-user.json`
 - Common flags on all binaries: `--env`, `--log-level`, `--json-logs`, `--logs-file`

--- a/build/npm/templates/package-darwin-amd64.json
+++ b/build/npm/templates/package-darwin-amd64.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gemyago/atlacp.git"
+    "url": "https://github.com/gemyago/atlacp"
   },
   "os": ["darwin"],
   "cpu": ["x64"],

--- a/build/npm/templates/package-darwin-amd64.json
+++ b/build/npm/templates/package-darwin-amd64.json
@@ -1,6 +1,10 @@
 {
   "name": "@atlacp/install-darwin-amd64",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gemyago/atlacp.git"
+  },
   "os": ["darwin"],
   "cpu": ["x64"],
   "files": ["bin/"],

--- a/build/npm/templates/package-darwin-arm64.json
+++ b/build/npm/templates/package-darwin-arm64.json
@@ -1,6 +1,10 @@
 {
   "name": "@atlacp/install-darwin-arm64",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gemyago/atlacp.git"
+  },
   "os": ["darwin"],
   "cpu": ["arm64"],
   "files": ["bin/"],

--- a/build/npm/templates/package-darwin-arm64.json
+++ b/build/npm/templates/package-darwin-arm64.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gemyago/atlacp.git"
+    "url": "https://github.com/gemyago/atlacp"
   },
   "os": ["darwin"],
   "cpu": ["arm64"],

--- a/build/npm/templates/package-install.json
+++ b/build/npm/templates/package-install.json
@@ -4,7 +4,7 @@
   "description": "Install atlacp tools (bbcp, bbmd)",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gemyago/atlacp.git"
+    "url": "https://github.com/gemyago/atlacp"
   },
   "files": ["install.mjs"],
   "scripts": {

--- a/build/npm/templates/package-install.json
+++ b/build/npm/templates/package-install.json
@@ -2,6 +2,10 @@
   "name": "@atlacp/install",
   "version": "0.0.0",
   "description": "Install atlacp tools (bbcp, bbmd)",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gemyago/atlacp.git"
+  },
   "files": ["install.mjs"],
   "scripts": {
     "postinstall": "node install.mjs"

--- a/build/npm/templates/package-linux-amd64.json
+++ b/build/npm/templates/package-linux-amd64.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gemyago/atlacp.git"
+    "url": "https://github.com/gemyago/atlacp"
   },
   "os": ["linux"],
   "cpu": ["x64"],

--- a/build/npm/templates/package-linux-amd64.json
+++ b/build/npm/templates/package-linux-amd64.json
@@ -1,6 +1,10 @@
 {
   "name": "@atlacp/install-linux-amd64",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gemyago/atlacp.git"
+  },
   "os": ["linux"],
   "cpu": ["x64"],
   "files": ["bin/"],

--- a/build/npm/templates/package-linux-arm64.json
+++ b/build/npm/templates/package-linux-arm64.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gemyago/atlacp.git"
+    "url": "https://github.com/gemyago/atlacp"
   },
   "os": ["linux"],
   "cpu": ["arm64"],

--- a/build/npm/templates/package-linux-arm64.json
+++ b/build/npm/templates/package-linux-arm64.json
@@ -1,6 +1,10 @@
 {
   "name": "@atlacp/install-linux-arm64",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gemyago/atlacp.git"
+  },
   "os": ["linux"],
   "cpu": ["arm64"],
   "files": ["bin/"],


### PR DESCRIPTION
# Focus of the changes
Adjust the npm publish workflow so it uses the trusted publishing path directly instead of asking setup-node to write registry auth config. The job now uses Node 24 and avoids the auth-token injection that was surfacing in the run logs.

# High level summary of the changes
* Removed `registry-url` from `.github/workflows/publish-npm.yml` so `actions/setup-node` no longer injects npm auth config.
* Pinned the workflow to Node 24 LTS.
* Added a short AGENTS note documenting the release-workflow expectation for trusted publishing.