### PR TITLE
Fix npm publish workflow to build dist first

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install Go dependencies
         run: go mod download && go install tool
 
+      - name: Build dist artifacts
+        run: make -C build dist
+
       - name: Publish npm packages
         env:
           VERSION_INPUT: ${{ github.event.inputs.version }}


### PR DESCRIPTION
This change adds a dist build step before npm/publish in GitHub Actions to ensure package files are present.