### PR TITLE
Fix npm install path resolution for scoped platform packages

### DIFF
--- a/build/npm/install/install.mjs
+++ b/build/npm/install/install.mjs
@@ -49,6 +49,7 @@ export function findPackageBinDir(
 
 function inferPackagesDir(scriptDir) {
   const candidates = [
+    path.resolve(scriptDir, 'node_modules'),
     path.resolve(scriptDir, '..', 'packages'),
     path.resolve(scriptDir, '..', '..'),
   ];

--- a/build/npm/install/install.test.mjs
+++ b/build/npm/install/install.test.mjs
@@ -146,3 +146,17 @@ test('resolveSourceBinDir infers package dir from script location', async () => 
   });
   assert.equal(resolved, localBinDir);
 });
+
+test('resolveSourceBinDir infers package dir from npm dependency layout', async () => {
+  const workspace = await mkdtemp(path.join(tmpdir(), 'atlacp-install-script-'));
+  const scriptDir = path.join(workspace, 'build', 'npm', 'install');
+  const dependencyBinDir = path.join(scriptDir, 'node_modules', '@atlacp', 'install-linux-amd64', 'bin');
+  await mkdir(dependencyBinDir, { recursive: true });
+  await writeFile(path.join(dependencyBinDir, 'bbcp'), '#!/bin/sh\necho local', 'utf8');
+
+  const resolved = resolveSourceBinDir({
+    packageName: '@atlacp/install-linux-amd64',
+    scriptDir,
+  });
+  assert.equal(resolved, dependencyBinDir);
+});


### PR DESCRIPTION
## Fix
- Update npm installer package path resolution to check install package local `node_modules` first when inferring package bin location.
- Add regression test for npm dependency layout where platform package is installed under `install/node_modules/@atlacp/...`.

## Validation
- `make lint`\n- `make test`\n- `make -C build test` (fails in this environment: missing Python dependency `faker`, unrelated to this fix)
