### PR TITLE
Improve npm installer UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The `bbmd` cli should be the superior to MCP when used by AI agents.
 Install the binaries:
 
 ```bash
-npm install -g @atlacp/install
+npx --yes @atlacp/install
 ```
 
 The installer places `bbmd` and `bbcp` in `~/.atlacp/bin` and updates your shell profile. Restart the shell, or source the updated profile before continuing. Follow [accounts setup](#account-setup) to configure Bitbucket account(s).

--- a/build/npm/install/install.mjs
+++ b/build/npm/install/install.mjs
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { accessSync } from 'node:fs';
 import {
   chmod,

--- a/build/npm/install/install.test.mjs
+++ b/build/npm/install/install.test.mjs
@@ -21,8 +21,8 @@ test('detectPlatformPackage maps supported and unsupported platforms', () => {
   assert.equal(detectPlatformPackage('win32', 'x64'), null);
 });
 
-test('isPathAlreadyConfigured returns true when /.atlacp/bin is present', () => {
-  const content = 'export PATH="$HOME/.atlacp/bin:$PATH"\n';
+test('isPathAlreadyConfigured returns true when atlacp env file is sourced', () => {
+  const content = 'source ~/.atlacp/env.sh\n';
   assert.equal(isPathAlreadyConfigured(content, '/home/user/.atlacp/bin'), true);
 });
 
@@ -31,7 +31,7 @@ test('isPathAlreadyConfigured returns false when /.atlacp/bin is absent', () => 
   assert.equal(isPathAlreadyConfigured(content, '/home/user/.atlacp/bin'), false);
 });
 
-test('appendToPath appends export PATH line', async () => {
+test('appendToPath appends atlacp shell setup', async () => {
   const tempDir = await mkdtemp(path.join(tmpdir(), 'atlacp-install-test-'));
   const configFile = path.join(tempDir, '.zshrc');
 
@@ -39,7 +39,8 @@ test('appendToPath appends export PATH line', async () => {
   await appendToPath(configFile, '/home/user/.atlacp/bin');
 
   const content = await readFile(configFile, 'utf8');
-  assert.match(content, /export PATH="\$HOME\/.atlacp\/bin:\$PATH"/);
+  assert.match(content, /# Added by @atlacp\/install/);
+  assert.match(content, /source ~\/.atlacp\/env\.sh/);
 });
 
 test('appendToPath is idempotent', async () => {
@@ -51,7 +52,7 @@ test('appendToPath is idempotent', async () => {
   await appendToPath(configFile, '/home/user/.atlacp/bin');
 
   const content = await readFile(configFile, 'utf8');
-  const occurrences = content.split('export PATH="$HOME/.atlacp/bin:$PATH"').length - 1;
+  const occurrences = content.split('source ~/.atlacp/env.sh').length - 1;
 
   assert.equal(occurrences, 1);
 });
@@ -76,7 +77,7 @@ test('detectShellConfigFiles returns bash config when shell ends with bash', () 
 
   try {
     process.env.SHELL = '/usr/local/bin/bash';
-    assert.deepEqual(detectShellConfigFiles(), ['~/.bashrc']);
+    assert.deepEqual(detectShellConfigFiles(), ['~/.bashrc', '~/.profile']);
   } finally {
     if (originalShell === undefined) {
       delete process.env.SHELL;

--- a/build/npm/templates/package-install.json
+++ b/build/npm/templates/package-install.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/gemyago/atlacp"
   },
   "files": ["install.mjs"],
-  "scripts": {
-    "postinstall": "node install.mjs"
+  "bin": {
+    "atlacp-install": "install.mjs"
   },
   "optionalDependencies": {
     "@atlacp/install-linux-amd64": "0.0.0",


### PR DESCRIPTION
# Focus of the changes
Switch the npm installer flow from an implicit global-install hook to explicit `npx` execution so users can see installer output immediately and the package behavior is less surprising.

# High level summary of the changes
* Replace the README install command with `npx --yes @atlacp/install`
* Expose the installer through a single npm `bin` entry and remove the `postinstall` hook
* Keep the installer entrypoint directly executable with a Node shebang
* Update installer tests to match the current shell setup behavior