### PR TITLE
Fix npx installer execution

### DIFF
--- a/build/npm/install/install.mjs
+++ b/build/npm/install/install.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { accessSync } from 'node:fs';
+import { accessSync, realpathSync } from 'node:fs';
 import {
   chmod,
   copyFile,
@@ -12,7 +12,7 @@ import {
 } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
 
 const EXPORT_PATH_LINE = 'export PATH="$HOME/.atlacp/bin:$PATH"';
 const ATLACP_INSTALL_COMMENT = '# Added by @atlacp/install';
@@ -185,6 +185,18 @@ async function writeEnvFile(installBaseDir) {
   return envFilePath;
 }
 
+export function isDirectExecution(moduleUrl = import.meta.url, executedPath = process.argv[1]) {
+  if (!executedPath) {
+    return false;
+  }
+
+  try {
+    return realpathSync(fileURLToPath(moduleUrl)) === realpathSync(executedPath);
+  } catch {
+    return false;
+  }
+}
+
 export async function run() {
   console.log(`Installing atlacp tools for ${process.platform}/${process.arch}`);
   const packageName = detectPlatformPackage();
@@ -219,7 +231,7 @@ export async function run() {
   console.log(`Restart your shell or run: ${SOURCE_ENV_LINE}`);
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (isDirectExecution()) {
   run().catch((err) => {
     console.error(`Failed to install atlacp binaries: ${err.message}`);
     process.exitCode = 1;

--- a/build/npm/install/install.test.mjs
+++ b/build/npm/install/install.test.mjs
@@ -1,13 +1,15 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, readFile, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import { pathToFileURL } from 'node:url';
 
 import {
   appendToPath,
   detectPlatformPackage,
   findPackageBinDir,
+  isDirectExecution,
   resolveSourceBinDir,
   detectShellConfigFiles,
   isPathAlreadyConfigured,
@@ -19,6 +21,18 @@ test('detectPlatformPackage maps supported and unsupported platforms', () => {
   assert.equal(detectPlatformPackage('darwin', 'x64'), '@atlacp/install-darwin-amd64');
   assert.equal(detectPlatformPackage('darwin', 'arm64'), '@atlacp/install-darwin-arm64');
   assert.equal(detectPlatformPackage('win32', 'x64'), null);
+});
+
+test('isDirectExecution returns true for the same file and symlinked entrypoint', async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), 'atlacp-install-entry-'));
+  const actualFile = path.join(tempDir, 'install.mjs');
+  const symlinkPath = path.join(tempDir, 'atlacp-install');
+
+  await writeFile(actualFile, 'console.log("test");\n', 'utf8');
+  await symlink(actualFile, symlinkPath);
+
+  assert.equal(isDirectExecution(pathToFileURL(actualFile).href, actualFile), true);
+  assert.equal(isDirectExecution(pathToFileURL(actualFile).href, symlinkPath), true);
 });
 
 test('isPathAlreadyConfigured returns true when atlacp env file is sourced', () => {


### PR DESCRIPTION
# Focus of the changes
Fix the npm installer entrypoint so `npx @atlacp/install` actually runs the installer instead of exiting silently when npm invokes the bin through a symlinked path.

# High level summary of the changes
* Resolve direct-execution detection by comparing real paths instead of raw module URLs
* Add a regression test for symlinked bin execution, which matches npm/npx invocation behavior
* Re-verify the packed installer executes successfully through npm exec from a tarball