### PR TITLE
docs: add project-local and global skill installation examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,31 @@ Use `bbmd skill` to teach your agent to use the cli. You can either write it to 
 Run `bbmd skill` to learn how to work with bitbucket.
 ```
 
-Or write the skill:
+Or write the skill in either project-local scope or global scope:
 ```bash
 # Opencode
+# Project-local
 mkdir -p .opencode/skills/bitbucket && bbmd skill > .opencode/skills/bitbucket/SKILL.md
+# Global
+mkdir -p ~/.opencode/skills/bitbucket && bbmd skill > ~/.opencode/skills/bitbucket/SKILL.md
 
 # Claude
+# Project-local
 mkdir -p .claude/skills/bitbucket && bbmd skill > .claude/skills/bitbucket/SKILL.md
+# Global
+mkdir -p ~/.claude/skills/bitbucket && bbmd skill > ~/.claude/skills/bitbucket/SKILL.md
 
 # Codex
+# Project-local
 mkdir -p .codex/skills/bitbucket && bbmd skill > .codex/skills/bitbucket/SKILL.md
+# Global
+mkdir -p ~/.codex/skills/bitbucket && bbmd skill > ~/.codex/skills/bitbucket/SKILL.md
 
 # Cursor
+# Project-local
 mkdir -p .cursor/skills/bitbucket && bbmd skill > .cursor/skills/bitbucket/SKILL.md
+# Global
+mkdir -p ~/.cursor/skills/bitbucket && bbmd skill > ~/.cursor/skills/bitbucket/SKILL.md
 ```
 __I'm so tired to have 20 folders with AI stuff...__
 


### PR DESCRIPTION
### Motivation
- Clarify where to write `bbmd` skill files by showing both project-local and global install locations for various agent skill folders.

### Description
- Update `README.md` to split skill installation examples into `Project-local` and `Global` variants and add global paths like `~/.opencode/skills/bitbucket`, `~/.claude/skills/bitbucket`, `~/.codex/skills/bitbucket`, and `~/.cursor/skills/bitbucket`, while keeping the `bbmd skill` examples.

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ef2c269c8333837fc9f5b6068186)